### PR TITLE
feat: initial workflow to build and upload cli

### DIFF
--- a/.github/workflows/publish-cli.yml
+++ b/.github/workflows/publish-cli.yml
@@ -1,0 +1,72 @@
+name: Build and upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: 'Version to use for release'
+        required: false
+  #TODO: read push commit name for release name
+  #push:
+  #  branches:
+  #    - 'release/**'
+
+jobs:
+  build:
+    name: Build and upload native cli for ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-18.04
+            file: scraped
+            target: x86_64-unknown-linux-gnu
+            asset_name: scraped-linux-x86_64
+          - os: windows-latest
+            file: scraped.exe
+            target: x86_64-pc-windows-msvc
+            asset_name: scraped-windows-x86_64.exe
+          - os: macos-latest
+            file: scraped
+            target: x86_64-apple-darwin
+            asset_name: scraped-macos-x86_64
+          - os: macos-latest
+            file: scraped
+            target: aarch64-apple-darwin
+            asset_name: scraped-macos-aarch64
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          default: true
+          override: true
+          toolchain: stable
+          target: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v1
+        with:
+          key: ${{ matrix.target }}
+          working-directory: cli
+
+      - name: Build
+        run: |
+          cd cli
+          cargo build --release --target ${{ matrix.target }}
+      - name: Strip binary
+        if: matrix.os != 'windows-latest'
+        run: |
+          cd cli/target/${{ matrix.target }}/release
+          strip -x scraped
+      - name: Upload
+        uses: svenstaro/upload-release-action@v2
+        with:
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          file: cli/target/${{ matrix.target }}/release/${{ matrix.file }}
+          tag: native-cli-${{ github.event.inputs.version }}
+          asset_name: ${{ matrix.asset_name }}
+          release_name: Native scraped cli ${{ github.event.inputs.version }}
+          overwrite: true


### PR DESCRIPTION
just wanna give you a starting point, feel free to dismiss this if you don't wanna use a gh action for this :shrug: 

The only real thing missing (if it's even wanted) is to upload on push to a release branch. Too tired to figure out tag/release names for it.

The resulting release looks like this: https://github.com/FabianLars/scraped/releases. It's kinda configurable in the last step, hopefully self-explanatory. The name for the uploaded asset is set in the matrix at the top.

Good night :sleepy: 

Edit: This probably needs to be rewritten once the napi-rs stuff is in place, but this gives us a quick&easy way to consume it in tauri-search for now.